### PR TITLE
chore: routeTree.gen.tsをbiomeの対象から外す

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -7,7 +7,7 @@
   },
   "files": {
     "ignoreUnknown": false,
-    "ignore": ["public"]
+    "ignore": ["public", "src/routeTree.gen.ts"]
   },
   "formatter": {
     "enabled": true,


### PR DESCRIPTION
## 背景

https://github.com/DaigakuNakayoshi/travelhelperkun-front/pull/5 で追加したファイルのうち、自動生成された`routeTree.gen.ts`がbiomeのlint規約に反していたためCIが失敗してしまっていたので、対応しました。
→マージタイミングのズレによってCI追加される前の状態だったため気づくことが遅れてしまいました。今後はこの手のlintのCIは正常に機能するので同じ事象(=CIで落ちるのにmainに取り込んでしまった事案)は起きません！

## 対応
自動生成系を毎回formatしなおすのは非現実的なので、ignoreしました。

## 確認

- CIがPassすること